### PR TITLE
Feat/first access validation

### DIFF
--- a/src/@types/user.ts
+++ b/src/@types/user.ts
@@ -12,6 +12,7 @@ export type User = {
   maxXp?: number;
   soundEnabled?: boolean;
   requiresPasswordReset?: boolean;
+  requiresProfileSetup?: boolean; 
   isActive?: boolean;
   lastLoginAt?: string;
 };

--- a/src/features/authentication/pages/onboarding-page.tsx
+++ b/src/features/authentication/pages/onboarding-page.tsx
@@ -42,7 +42,7 @@ export function OnboardingPage() {
 
   // If user already has a name, redirect to dashboard
   useEffect(() => {
-    if (user?.name) {
+    if (user?.name && !user?.requiresProfileSetup) {
       navigate('/dashboard');
     }
   }, [user, navigate]);

--- a/src/features/authentication/stores/auth-store.ts
+++ b/src/features/authentication/stores/auth-store.ts
@@ -42,7 +42,9 @@ export const useAuthStore = create<AuthStoreState>((set) => ({
       await import('../services/user');
     const updatedUser = await updateProfileService(data);
     set((state) => ({
-      user: state.user ? { ...state.user, ...updatedUser } : null,
+      user: state.user
+        ? { ...state.user, ...updatedUser, requiresProfileSetup: false }
+        : null,
     }));
   },
   updateSettings: async (data) => {
@@ -50,7 +52,9 @@ export const useAuthStore = create<AuthStoreState>((set) => ({
       await import('../services/user');
     const updatedUser = await updateSettingsService(data);
     set((state) => ({
-      user: state.user ? { ...state.user, ...updatedUser } : null,
+      user: state.user 
+      ? { ...state.user, ...updatedUser, requiresProfileSetup: false }
+      : null,
     }));
   },
   resetPassword: async (data) => {

--- a/src/templates/private-route.tsx
+++ b/src/templates/private-route.tsx
@@ -68,11 +68,26 @@ export const ProtectedRoute = ({
     return <Navigate to={redirect} replace />;
   }
 
+  const isForceResetRoute = window.location.pathname === '/force-reset-password';
+  if (user?.requiresPasswordReset && !isForceResetRoute) {
+    return <Navigate to="/force-reset-password" replace />;
+  }
+
   const isOnboardingRoute = window.location.pathname === '/onboarding';
+  if (
+    user &&
+    !user.requiresPasswordReset &&
+    user.requiresProfileSetup &&
+    !isOnboardingRoute
+  ) {
+    return <Navigate to="/onboarding" replace />;
+  }
+
   if (
     user &&
     !user.name &&
     !user.requiresPasswordReset &&
+    !user.requiresProfileSetup &&
     user.role === 'STUDENT' &&
     !isOnboardingRoute
   ) {


### PR DESCRIPTION
**Implement first-access UI flow for content creators**

This PR adds the frontend handling for the mandatory first-access flow introduced on the API side. After logging in with a temporary password, content creators are guided through a password reset step and a profile setup step before reaching the dashboard.

**Changes**

- Added `requiresProfileSetup` to the `User` type
- `ProtectedRoute` now contains two new guards: one that redirects to `/force-reset-password` when `requiresPasswordReset` is `true`, and one that redirects to `/onboarding` when `requiresProfileSetup` is `true` and the password has already been reset; the existing student onboarding guard was preserved and made non-conflicting
- `auth-store` now clears `requiresProfileSetup` locally after a successful `updateProfile` call, preventing a refetch race condition from reverting the flag
- Fixed the `OnboardingPage` redirect condition to check both `user.name` and `!user.requiresProfileSetup`, eliminating the redirect loop that occurred when the `/me` refetch returned before the store update settled